### PR TITLE
Fix certificate not showing in public

### DIFF
--- a/frontend/src/pages/Welcome.vue
+++ b/frontend/src/pages/Welcome.vue
@@ -209,7 +209,7 @@
 			</div>
 
 			<div class="bg-white rounded-xl p-6 border-l-4 border-red-500 shadow">
-				<p class="text-gray-500 text-sm">Courses At Risk</p>
+				<p class="text-gray-500 text-sm">Mandatory Courses</p>
 				<p class="text-3xl font-bold mt-2">{{ courseAtRisk }}</p>
 			</div>
 

--- a/lms/lms/doctype/lms_certificate/lms_certificate.py
+++ b/lms/lms/doctype/lms_certificate/lms_certificate.py
@@ -245,6 +245,7 @@ def create_certificate(course):
             "issue_date": issue_date,
             "expiry_date": expiry_date,
             "template": default_certificate_template,
+            "published": 1
         }
     )
     cert_doc.save(ignore_permissions=True)


### PR DESCRIPTION
- Fix certificate not showing in public
- change dashboard label "At Risk" to "Mandatory Courses"